### PR TITLE
Shinytheme의 에러 발생

### DIFF
--- a/func.R
+++ b/func.R
@@ -13,3 +13,24 @@ tab_im <- function(text, cor,id){
 
 ## origin version ##
 cores <- c("#0A043C", "#098ebb", "#fdc23a", "#e96449", "#D3BBAF", "#ddcdbf", "#e6c26c") # color range
+
+# 경로설정.
+volumes = c('wd'='.')
+
+# 에러 대처용. shinythemes() 함수 동작하지 않음.
+shinytheme <- function(theme = NULL) {
+  # Check that theme exists
+  if (is.null(theme) || !theme %in% allThemes()) {
+    stop(theme, " is not an available theme. Valid themes are: ",
+         paste(allThemes(), collapse = ", "), ".")
+  }
+  
+  paste0("shinythemes/css/", theme, ".min.css")
+}
+
+
+# 해당 함수가 변경되었음.
+allThemes <- function() {
+  themes <- dir(system.file("shinythemes/css", package = "shinythemes"), ".min.css")
+  sub(".min.css", "", themes)
+}

--- a/runApp.R
+++ b/runApp.R
@@ -11,7 +11,6 @@ library(reticulate)
 ### Miniconda ###
 install_miniconda()
 py_install('pandas')
-volumes = c('wd'='.')
 
 ### file load ###
 source("func.R")
@@ -33,7 +32,7 @@ ui<-fluidPage(
                                          '.navbar-default .navbar-nav>.active>a, .navbar-default .navbar-nav>.active>a:hover, 
                                          .navbar-default .navbar-nav>.active>a:focus  {background-color: #11324D;}',
                                          '.btn-default {background-color: #11324D;}',
-                                         '.btn-default.active {background-color: #11324D;}',
+                                         '.btn-default.active {background-color: #11324D;}', 
                                          '.btn-default:focus, .btn-default.focus {background-color: #11324D;}',
                                          '.btn-default:hover {background-color: #11324D;}',
                                          '.btn-default:active:hover, .btn-default.active:hover, .open>.dropdown-toggle.btn-default:hover, .btn-default:active:focus, .btn-default.active:focus, .open>.dropdown-toggle.btn-default:focus, .btn-default:active.focus, .btn-default.active.focus, .open>.dropdown-toggle.btn-default.focus {background-color: #4B6587;}',


### PR DESCRIPTION
코드 재설치시
shinytheme()함수가 에러 발생하는것을 확인.
allThemes() 함수가 적절한 파일을 가져오지 못함.

allThemes <- function() {
  themes <- dir(system.file("shinythemes/css", package = "shinythemes"), "*.min.css")
  sub(".min.css", "", themes)
}

에서 "*.min.css" ==> ".min.css"로 변경하여 사용함.